### PR TITLE
Updated Wikipedia script - now grabs first paragraph

### DIFF
--- a/scripts/Misc APIs/Wikipedia.csx
+++ b/scripts/Misc APIs/Wikipedia.csx
@@ -1,10 +1,10 @@
-/*
+/**
 * <description>
 *    Queries wikipedia.org
 * </description>
 *
 * <commands>
-*    mmbot wiki me <query> - responds with Wikipedia's most likely page.
+*    mmbot wiki me &lt;query&gt; - responds with Wikipedia's most likely page.
 * </commands>
 * 
 * <notes>


### PR DESCRIPTION
not happy it's using System.Text.RegularExpressions, let me know if there's something obvious I am missing - couldn't figure out how to do regex stuff without it.

It should work 95% of the time, there's some edge cases which can generally be ignored (or I'll change later) like the pronunciation section or some unit conversion (I noticed kilometres -> miles)
