### PR TITLE
Fixed NullReferenceException thrown executing "show me builds" command

### DIFF
--- a/scripts/Source Control/TeamCity.csx
+++ b/scripts/Source Control/TeamCity.csx
@@ -57,7 +57,7 @@ if (_hostname != null)
 
     robot.Respond("show me builds$", msg => GetCurrentBuilds(robot, msg, null, (err, res, body) =>
     {
-        if (err == null && body["count"].Value<int>() == 0)
+        if (err == null && (body["count"] == null || body["count"].Value<int>() == 0))
         {
             msg.Send("No builds are currently running");
             return;


### PR DESCRIPTION
Fixed NullReferenceException thrown executing "show me builds" when no builds are currently running in TeamCity. In this case the only member in the JSON result is "href" so the "count" member cannot be accessed. I have left the existing "count" check in place as well, just in case earlier versions of the TeamCity API did return this member when no builds are running. I am currently running TeamCity Enterprise 8.1.1 in case it is of interest.
