### PR TITLE
Avoid "&mdash;"'s in quotes

### DIFF
--- a/scripts/Misc APIs/DefProgramming.csx
+++ b/scripts/Misc APIs/DefProgramming.csx
@@ -20,6 +20,8 @@
 * </author>
 */
 
+using System.Net;
+
 var robot = Require<Robot>();
 private Random _rand = new Random();
 
@@ -34,9 +36,9 @@ robot.Respond(@"def programming", msg =>
             else
             {
                 try {
-                    var quote = htmlDoc.DocumentNode.SelectNodes("//q[@class='jumbotron']/p").First().FirstChild.InnerText;
-                    var author = htmlDoc.DocumentNode.SelectNodes("//span[@class='quote-highlight-author-name']").First().FirstChild.InnerText;
-                    var topic = htmlDoc.DocumentNode.SelectNodes("//span[@class='quote-highlight-tags']/a").First().FirstChild.InnerText;
+                    var quote = WebUtility.HtmlDecode(htmlDoc.DocumentNode.SelectNodes("//q[@class='jumbotron']/p").First().FirstChild.InnerText);
+                    var author = WebUtility.HtmlDecode(htmlDoc.DocumentNode.SelectNodes("//span[@class='quote-highlight-author-name']").First().FirstChild.InnerText);
+                    var topic = WebUtility.HtmlDecode(htmlDoc.DocumentNode.SelectNodes("//span[@class='quote-highlight-tags']/a").First().FirstChild.InnerText);
                     msg.Send(string.Format("\"{0}\" - {1} on {2}", quote, author, topic));
                 }
                 catch


### PR DESCRIPTION
I noticed some quotes coming back had HTML escaping in them like "&mdash;". This change should fix that.

Thanks for all your work on mmbot! I'm just starting to use it internally and am having fun writing my own scripts.
